### PR TITLE
Exception throw when manually enqueueing: StatusCode cannot be set because the response has already started

### DIFF
--- a/Pages/ManagementBasePage.cs
+++ b/Pages/ManagementBasePage.cs
@@ -188,8 +188,8 @@ namespace Hangfire.Core.Dashboard.Management.Pages
                     if (!string.IsNullOrEmpty(jobLink))
                     {
                         var responseObj = new { jobLink };
-                        context.Response.WriteAsync(JsonConvert.SerializeObject(responseObj));
                         context.Response.StatusCode = (int) HttpStatusCode.OK;
+                        context.Response.WriteAsync(JsonConvert.SerializeObject(responseObj));
                         return true;
                     }
                     return false;


### PR DESCRIPTION
Exception is thrown when manually enqueueing a job from a .NET Core project. I think that just setting the status code before writing the response might fix it.

System.InvalidOperationException: 'StatusCode cannot be set because the response has already started.'

![image](https://user-images.githubusercontent.com/9166531/50213049-cfe17c80-037c-11e9-81c7-9fe45c925694.png)