### PR TITLE
Selecting a page in management shows all Jobs from the same queue

### DIFF
--- a/GlobalConfigurationExtension.cs
+++ b/GlobalConfigurationExtension.cs
@@ -24,12 +24,12 @@ namespace Hangfire.Core.Dashboard.Management
             {
                 ManagementBasePage.AddCommands(pageInfo.Queue);
 
-                ManagementSidebarMenu.Items.Add(p => new MenuItem(pageInfo.MenuName, p.Url.To($"{ManagementPage.UrlRoute}/{pageInfo.Queue}"))
+                ManagementSidebarMenu.Items.Add(p => new MenuItem(pageInfo.MenuName, p.Url.To($"{ManagementPage.UrlRoute}/{pageInfo.Title}"))
                 {
-                    Active = p.RequestPath.StartsWith($"{ManagementPage.UrlRoute}/{pageInfo.Queue}")
+                    Active = p.RequestPath.StartsWith($"{ManagementPage.UrlRoute}/{pageInfo.Title}")
                 });
 
-                DashboardRoutes.Routes.AddRazorPage($"{ManagementPage.UrlRoute}/{pageInfo.Queue}", x => new ManagementBasePage(pageInfo.Title, pageInfo.Title, pageInfo.Queue));
+                DashboardRoutes.Routes.AddRazorPage($"{ManagementPage.UrlRoute}/{pageInfo.Title}", x => new ManagementBasePage(pageInfo.Title, pageInfo.Title, pageInfo.Queue));
             }
             
             //note: have to use new here as the pages are dispatched and created each time. If we use an instance, the page gets duplicated on each call

--- a/Hangfire.Core.Dashboard.Management.csproj
+++ b/Hangfire.Core.Dashboard.Management.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{56858540-6404-4F8F-ABFA-9C6043FBD551}</ProjectGuid>
+    <ProjectGuid>{488B40E8-402F-4901-A40C-2D8A1A2D03B6}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Hangfire.Core.Dashboard.Management</RootNamespace>
@@ -31,10 +31,6 @@
     <DocumentationFile>bin\Release\Hangfire.Core.Dashboard.Management.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Hangfire.Core, Version=1.6.8.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Hangfire.Core.1.6.8\lib\net45\Hangfire.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -78,6 +74,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="management.PNG" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Hangfire\src\Hangfire.Core\Hangfire.Core.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Metadata/JobMetadata.cs
+++ b/Metadata/JobMetadata.cs
@@ -5,10 +5,13 @@ namespace Hangfire.Core.Dashboard.Management.Metadata
 {
     public class JobMetadata
     {
+
         public string DisplayName { get; set; }
         public string Description { get; set; }
         public string Queue { get; set; }
+        public string PageTitle { get; set; }
         public Type Type { get; set; }
         public MethodInfo MethodInfo { get; set; }
+        
     }
 }

--- a/Pages/ManagementBasePage.cs
+++ b/Pages/ManagementBasePage.cs
@@ -30,7 +30,7 @@ namespace Hangfire.Core.Dashboard.Management.Pages
 
         protected virtual void Content()
         {
-            var jobs = JobsHelper.Metadata.Where(j => j.Queue.Contains(queue));
+            var jobs = JobsHelper.Metadata.Where(j => j.PageTitle.Contains(pageTitle));
 
             foreach (var jobMetadata in jobs)
             {

--- a/Pages/ManagementBasePage.cs
+++ b/Pages/ManagementBasePage.cs
@@ -34,8 +34,8 @@ namespace Hangfire.Core.Dashboard.Management.Pages
 
             foreach (var jobMetadata in jobs)
             {
-                var route = $"{ManagementPage.UrlRoute}/{queue}/{jobMetadata.DisplayName.Replace(" ", string.Empty)}";
-                var id = $"{jobMetadata.DisplayName.Replace(" ", string.Empty)}";
+                var route = $"{ManagementPage.UrlRoute}/{queue}/{jobMetadata.DisplayName?.Replace(" ", string.Empty) ?? jobMetadata.Type.Name}";
+                var id = $"{jobMetadata.DisplayName?.Replace(" ", string.Empty) ?? jobMetadata.Type.Name}";
 
                 if (jobMetadata.MethodInfo.GetParameters().Length > 1)
                 {
@@ -73,7 +73,8 @@ namespace Hangfire.Core.Dashboard.Management.Pages
                         }
                         else
                         {
-                            throw new NotImplementedException();
+                            Logging.LogProvider.GetCurrentClassLogger().Log(Logging.LogLevel.Warn, () => "Parameter-type is not supported.");
+                            //throw new NotImplementedException();
                         }
                     }
 
@@ -100,17 +101,19 @@ namespace Hangfire.Core.Dashboard.Management.Pages
 
             foreach (var jobMetadata in jobs)
             {
-                var route = $"{ManagementPage.UrlRoute}/{queue}/{jobMetadata.DisplayName.Replace(" ", string.Empty)}";
+                var route = $"{ManagementPage.UrlRoute}/{queue}/{jobMetadata.DisplayName?.Replace(" ", string.Empty) ?? jobMetadata.Type.Name}";
 
                 DashboardRoutes.Routes.Add(route, new CommandWithResponseDispatcher(context =>
                 {
                     var par = new List<object>();
+
                     var schedule = Task
                         .Run(() => context.Request.GetFormValuesAsync(
                             $"{jobMetadata.DisplayName.Replace(" ", string.Empty)}_schedule")).Result.FirstOrDefault();
                     var cron = Task
                         .Run(() => context.Request.GetFormValuesAsync(
                             $"{jobMetadata.DisplayName.Replace(" ", string.Empty)}_cron")).Result.FirstOrDefault();
+
 
                     foreach (var parameterInfo in jobMetadata.MethodInfo.GetParameters())
                     {
@@ -129,6 +132,7 @@ namespace Hangfire.Core.Dashboard.Management.Pages
                         }
 
                         var t = Task.Run(() => context.Request.GetFormValuesAsync(variable)).Result;
+
 
                         object item = null;
                         var formInput = t.FirstOrDefault();
@@ -150,7 +154,8 @@ namespace Hangfire.Core.Dashboard.Management.Pages
                         }
                         else
                         {
-                            throw new NotImplementedException();
+                            Logging.LogProvider.GetCurrentClassLogger().Log(Logging.LogLevel.Warn, () => "Parameter-type is not supported.");
+                            //throw new NotImplementedException();
                         }
 
                         par.Add(item);

--- a/Support/JobsHelper.cs
+++ b/Support/JobsHelper.cs
@@ -20,18 +20,20 @@ namespace Hangfire.Core.Dashboard.Management.Support
             foreach (Type ti in  assembly.GetTypes().Where(x => !x.IsInterface && typeof(IJob).IsAssignableFrom(x) && x.Name != (typeof(IJob).Name)))
             {
                 var q="default";
+                var title = "Default";
 
                 if (ti.GetCustomAttributes(true).OfType<ManagementPageAttribute>().Any())
                 {
                     var attr = ti.GetCustomAttribute<ManagementPageAttribute>();
                     q =  attr.Queue;
+                    title = attr.Title;
                     Pages.Add(attr);
                 }
                 
 
                 foreach (var methodInfo in ti.GetMethods().Where(m => m.DeclaringType == ti))
                 {
-                    var meta = new JobMetadata { Type = ti, Queue = q};
+                    var meta = new JobMetadata { Type = ti, Queue = q, PageTitle = title};
 
                     if (methodInfo.GetCustomAttributes(true).OfType<DescriptionAttribute>().Any())
                     {

--- a/Support/JobsHelper.cs
+++ b/Support/JobsHelper.cs
@@ -34,7 +34,7 @@ namespace Hangfire.Core.Dashboard.Management.Support
                 foreach (var methodInfo in ti.GetMethods().Where(m => m.DeclaringType == ti))
                 {
                     var meta = new JobMetadata { Type = ti, Queue = q, PageTitle = title};
-
+                    meta.MethodInfo = methodInfo;
                     if (methodInfo.GetCustomAttributes(true).OfType<DescriptionAttribute>().Any())
                     {
                         meta.Description = methodInfo.GetCustomAttribute<DescriptionAttribute>().Description;
@@ -42,7 +42,7 @@ namespace Hangfire.Core.Dashboard.Management.Support
 
                     if (methodInfo.GetCustomAttributes(true).OfType<DisplayNameAttribute>().Any())
                     {
-                        meta.MethodInfo = methodInfo;
+                        
                         meta.DisplayName = methodInfo.GetCustomAttribute<DisplayNameAttribute>().DisplayName;
                     }
 

--- a/Support/JobsHelper.cs
+++ b/Support/JobsHelper.cs
@@ -27,7 +27,7 @@ namespace Hangfire.Core.Dashboard.Management.Support
                     var attr = ti.GetCustomAttribute<ManagementPageAttribute>();
                     q =  attr.Queue;
                     title = attr.Title;
-                    Pages.Add(attr);
+                    if(!Pages.Any(x => x.Title == title)) Pages.Add(attr);
                 }
                 
 

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hangfire.Core" version="1.6.8" targetFramework="net462" />
+  <package id="Hangfire.Core" version="1.6.21" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
   <package id="Owin" version="1.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
A new ManagementSidebarMenu item is created for every IJob implementation in the consumers project, even if a page with the same name already exists. Clicking on the pages in the SidebarMenu however lists all the IJob instances which are set to the same queue.

This pull request changes the routes from using the url /management/{queue} to use the the URL /management/{pagetitle}.
I've also added a check so there's only one SidebarMenu item created per distinct PageTitle.