### PR TITLE
Filter methods to only return standard methods

### DIFF
--- a/Support/JobsHelper.cs
+++ b/Support/JobsHelper.cs
@@ -27,9 +27,9 @@ namespace Hangfire.Core.Dashboard.Management.Support
                     q =  attr.Queue;
                     Pages.Add(attr);
                 }
-                
 
-                foreach (var methodInfo in ti.GetMethods().Where(m => m.DeclaringType == ti))
+
+                foreach (var methodInfo in ti.GetMethods().Where(m => ! m.IsSpecialName && m.DeclaringType == ti))
                 {
                     var meta = new JobMetadata { Type = ti, Queue = q};
 


### PR DESCRIPTION
JobsHelper is returning all Methods, Properties and Events on a
containing type.  This causes problems on more complicated job
definitions.

Use IsSpecialName to only return regular invokable methods.